### PR TITLE
Settings: Implement lockscreen quick unlock [2/2]

### DIFF
--- a/src/com/android/settings/password/ChooseLockGeneric.java
+++ b/src/com/android/settings/password/ChooseLockGeneric.java
@@ -996,6 +996,7 @@ public class ChooseLockGeneric extends SettingsActivity {
                                 lock.defaultQuality,
                                 lock == ScreenLockType.NONE,
                                 false /* chooseLockSkipped */);
+                        mLockPatternUtils.setPinPasswordLength(-1, mUserId);
                         return true;
                     case PATTERN:
                     case PIN:

--- a/src/com/android/settings/password/ChooseLockPassword.java
+++ b/src/com/android/settings/password/ChooseLockPassword.java
@@ -745,6 +745,7 @@ public class ChooseLockPassword extends SettingsActivity {
             } else if (mUiStage == Stage.NeedToConfirm) {
                 if (mChosenPassword.equals(mFirstPassword)) {
                     startSaveAndFinish();
+                    mLockPatternUtils.setPinPasswordLength(mChosenPassword.size(), mUserId);
                 } else {
                     CharSequence tmp = mPasswordEntry.getText();
                     if (tmp != null) {

--- a/src/com/android/settings/password/ChooseLockPattern.java
+++ b/src/com/android/settings/password/ChooseLockPattern.java
@@ -663,6 +663,7 @@ public class ChooseLockPattern extends SettingsActivity {
                             + " when button is " + RightButtonMode.Confirm);
                 }
                 startSaveAndFinish();
+                mLockPatternUtils.setPinPasswordLength(-1, mUserId);
             } else if (mUiStage.rightMode == RightButtonMode.Ok) {
                 if (mUiStage != Stage.HelpScreen) {
                     throw new IllegalStateException("Help screen is only mode with ok button, "


### PR DESCRIPTION
Make Quick Unlock compatible with long PIN/Password.

    * Idea from OnePlus OOS.

[Pranav Vashi <neobuddy89@gmail.com>]:
    * Forward port to Android 12

[Jyotiraditya Panda <jyotiraditya@aospa.co>]:
    * Code cleanup and format

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>
Signed-off-by: Jyotiraditya Panda <jyotiraditya@aospa.co>
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>
Change-Id: I9a39cdc8c53ee46cd0331f946bbe53aa6c5a0bac